### PR TITLE
Multi key save

### DIFF
--- a/siteconfigs/admin.py
+++ b/siteconfigs/admin.py
@@ -4,7 +4,8 @@ from django.contrib import admin
 from .models import SiteConfigModel
 
 class SiteConfigModelAdmin(admin.ModelAdmin):
-    pass
+    list_display = ["key", "site"]
+    search_fields = ["key", "site__name"]
 
 
 admin.site.register(SiteConfigModel, SiteConfigModelAdmin)

--- a/siteconfigs/config.py
+++ b/siteconfigs/config.py
@@ -27,11 +27,16 @@ class SiteConfigBaseClass():
             return self.value
         return self.default
 
-    def save(self, data, value_key):
+    # can pass in a dictionary or a single key and value
+    # easier to accomodate settings with multiple values
+    def save(self, data, value_key = None):
         config, created = SiteConfigModel.objects.get_or_create(site=self.site, key=self.key)
-        config.value = {
-            value_key: data
-        }
+        if value_key:
+            config.value.update({
+                value_key: data
+            })
+        elif isinstance(data, dict):
+            config.value.update(data)
         config.save()
         self.instance = config
         self.value = config.value

--- a/siteconfigs/tests.py
+++ b/siteconfigs/tests.py
@@ -32,6 +32,14 @@ class ExampleTests(TestCase):
         self.assertEqual(example.value, setting.value)
         self.assertEqual(example.value, {"test key": "new value"})
 
+    def test_save_via_dict(self):
+        example = ExampleClass()
+        test_data = {"hello": "world", "test": "value"}
+        example.save(test_data)
+        self.assertEqual(example.value, test_data)
+        self.assertEqual(example.get_key_value("hello"), "world")
+        self.assertEqual(example.get_key_value("test"), "value")
+
     def test_delete(self):
         ExampleClass().save("Testing", "example")
         self.assertEqual(SiteConfigModel.objects.count(), 1)


### PR DESCRIPTION
* Make saving values with multiple keys easier by using update instead of overriding current dictionary
* Allow users to pass in a dictionary when saving so they can update multiple values at once
* More convenient admin section